### PR TITLE
Workspace assignment focus

### DIFF
--- a/home-manager/home-desktop.nix
+++ b/home-manager/home-desktop.nix
@@ -177,15 +177,25 @@
     workspaces = [
         {
             name = "1";
-            programs = [ "Alacritty" "kitty" ];
+            # programs = [ "Alacritty" "kitty" ];
+            programs = [
+                {name = "Alacritty"; focus = true;}
+                {name = "kitty"; focus = true;}
+            ];
         }
         {
             name = "2";
-            programs = [ "firefox" ];
+            # programs = [ "firefox" ];
+            programs = [
+                {name = "firefox"; focus = true;}
+            ];
         }
         {
             name = "3";
-            programs = [ "FreeTube" ];
+            # programs = [ "FreeTube" ];
+            programs = [
+                {name = "FreeTube"; focus = true;}
+            ];
         }
         {
             name = "4";
@@ -193,7 +203,12 @@
         }
         {
             name = "5";
-            programs = [ "steam" "gamescope" "com.usebottles.bottles" ];
+            # programs = [ "steam" "gamescope" "com.usebottles.bottles" ];
+            programs = [
+                {name = "Steam";}
+                {name = "gamescope";}
+                {name = "com.usebottles.bottles";}
+            ];
         }
         {
             name = "6";
@@ -201,7 +216,13 @@
         }
         {
             name = "7";
-            programs = [ "Keybase" "discord" "chatterino" "com.chatterino.chatterino" ];
+            # programs = [ "Keybase" "discord" "chatterino" "com.chatterino.chatterino" ];
+            programs = [
+                {name = "Keybase";}
+                {name = "discord";}
+                {name = "chatterino";}
+                {name = "com.chatterino.chatterino";}
+            ];
         }
         {
             name = "8";
@@ -209,11 +230,14 @@
         }
         {
             name = "9";
-            programs = [ "pavucontrol" "org.freedesktop.ryuukyu.Helvum" ];
+            # programs = [ "pavucontrol" "org.freedesktop.ryuukyu.Helvum" ];
         }
         {
             name = "10";
-            programs = [ "VSCodium" ];
+            # programs = [ "VSCodium" ];
+            programs = [
+                {name = "VSCodium"; focus = true;}
+            ];
         }
     ];
 

--- a/home-manager/home-desktop.nix
+++ b/home-manager/home-desktop.nix
@@ -177,7 +177,6 @@
     workspaces = [
         {
             name = "1";
-            # programs = [ "Alacritty" "kitty" ];
             programs = [
                 {name = "Alacritty"; focus = true;}
                 {name = "kitty"; focus = true;}
@@ -185,14 +184,12 @@
         }
         {
             name = "2";
-            # programs = [ "firefox" ];
             programs = [
                 {name = "firefox"; focus = true;}
             ];
         }
         {
             name = "3";
-            # programs = [ "FreeTube" ];
             programs = [
                 {name = "FreeTube"; focus = true;}
             ];
@@ -203,7 +200,6 @@
         }
         {
             name = "5";
-            # programs = [ "steam" "gamescope" "com.usebottles.bottles" ];
             programs = [
                 {name = "Steam";}
                 {name = "gamescope";}
@@ -216,7 +212,6 @@
         }
         {
             name = "7";
-            # programs = [ "Keybase" "discord" "chatterino" "com.chatterino.chatterino" ];
             programs = [
                 {name = "Keybase";}
                 {name = "discord";}
@@ -230,11 +225,13 @@
         }
         {
             name = "9";
-            # programs = [ "pavucontrol" "org.freedesktop.ryuukyu.Helvum" ];
+            programs = [
+                {name = "pavucontrol";}
+                {name = "org.freedesktop.ryuukyu.Helvum";}
+            ];
         }
         {
             name = "10";
-            # programs = [ "VSCodium" ];
             programs = [
                 {name = "VSCodium"; focus = true;}
             ];

--- a/home-manager/home-laptop.nix
+++ b/home-manager/home-laptop.nix
@@ -150,15 +150,22 @@
     workspaces = [
         {
             name = "1";
-            programs = [ "Alacritty" "kitty" ];
+            programs = [
+                {name ="Alacritty"; focus = true;}
+                {name ="kitty"; focus = true;}
+            ];
         }
         {
             name = "2";
-            programs = [ "firefox" ];
+            programs = [
+                {name = "firefox"; focus = true;}
+            ];
         }
         {
             name = "3";
-            programs = [ "FreeTube" ];
+            programs = [
+                {name = "FreeTube"; focus = true;}
+            ];
         }
         {
             name = "4";
@@ -166,7 +173,11 @@
         }
         {
             name = "5";
-            programs = [ "steam" "gamescope" "com.usebottles.bottles" ];
+            programs = [
+                {name = "steam";}
+                {name = "gamescope";}
+                {name = "com.usebottles.bottles";}
+            ];
         }
         {
             name = "6";
@@ -174,15 +185,25 @@
         }
         {
             name = "7";
-            programs = [ "Keybase" "discord" "chatterino" "com.chatterino.chatterino" ];
+            programs = [
+                {name = "Keybase";}
+                {name = "discord";}
+                {name = "chatterino";}
+                {name = "com.chatterino.chatterino";}
+            ];
         }
         {
             name = "8";
-            programs = [ "VSCodium" ];
+            programs = [
+                {name = "VSCodium";}
+            ];
         }
         {
             name = "9";
-            programs = [ "pavucontrol" "org.freedesktop.ryuukyu.Helvum" ];
+            programs = [
+                {name = "pavucontrol";}
+                {name = "org.freedesktop.ryuukyu.Helvum";}
+            ];
         }
         {
             name = "10";

--- a/home-manager/window-managers/hyprland.nix
+++ b/home-manager/window-managers/hyprland.nix
@@ -138,10 +138,12 @@
             windowrulev2 = lib.lists.flatten [
                 (map (w:
                     map (p:
-                        "workspace ${w.name}, class:${p}"
-                    )
-                (w.programs))
-                (config.workspaces))
+                        let
+                            wsfocus = (if p.focus then "workspace ${w.name}" else "workspace ${w.name} silent");
+                        in
+                        "${wsfocus}, class:${p.name}"
+                    )(w.programs)
+                )(config.workspaces))
                 "noanim, class:FreeTube"
                 "tile, title:^(Chatterino\\s\\d\\.\\d\\.\\d)"
                 "center, title:^(Chatterino Settings)"

--- a/home-manager/window-managers/sway.nix
+++ b/home-manager/window-managers/sway.nix
@@ -15,6 +15,15 @@ let
     ws8 = "8";
     ws9 = "9";
     ws0 = "10";
+
+    wsf = lib.lists.flatten (builtins.map (w:
+        builtins.map (p:
+            let
+                wsfocus = (if p.focus then "for_window [app_id=\"${p.name}\"] focus\nfor_window [class=\"${p.name}\"] focus\n" else "");
+            in
+            "${wsfocus}"
+        )(w.programs)
+    )(config.workspaces));
 in
 {
     wayland.windowManager.sway = {
@@ -25,8 +34,8 @@ in
                 {
                     name = w.name;
                     value = lib.lists.flatten (map (p: [
-                        {app_id = p;}
-                        {class = p;}
+                        {app_id = p.name;}
+                        {class = p.name;}
                     ])
                     (w.programs));
                 })
@@ -278,11 +287,8 @@ in
             );
         };
         extraConfig = ''
-            for_window [app_id="Alacritty"] focus
-            for_window [app_id="firefox"] focus
-            for_window [class="firefox"] focus
+            ${lib.strings.concatStringsSep "" wsf}
             for_window [app_id="firefox"] opacity 1.0
-            for_window [class="FreeTube"] focus
             for_window [class="steam"] move to workspace ${ws5}
         '';
         extraSessionCommands = ''

--- a/options.nix
+++ b/options.nix
@@ -220,10 +220,26 @@ with lib;
                         example = "1";
                     };
                     programs = mkOption {
-                        type = types.listOf types.str;
-                        example = [ "firefox" ];
+                        type = types.listOf (types.submodule {
+                            options = {
+                                name = mkOption {
+                                    type = types.str;
+                                    example = "firefox";
+                                };
+                                focus = mkOption {
+                                    type = types.bool;
+                                    example = true;
+                                    default = false;
+                                };
+                            };
+                        });
                         default = [ ];
                     };
+                    # programs = mkOption {
+                    #     type = types.listOf types.str;
+                    #     example = [ "firefox" ];
+                    #     default = [ ];
+                    # };
                 };
             });
             default = [ ];


### PR DESCRIPTION
Changed how assigning program to workspace by using submodules instead of strings to be able to set which program that should focus when launching