### PR TITLE
Update 24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -95,9 +95,7 @@
     "m4b-tool": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1722229572,
@@ -116,16 +114,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733412085,
-        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "lastModified": 1680758185,
+        "narHash": "sha256-sCVWwfnk7zEX8Z+OItiH+pcSklrlsLZ4TJTtnxAYREw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "rev": "0e19daa510e47a40e06257e205965f3b96ce0ac9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -146,12 +144,28 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1733412085,
+        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "firefox-addons": "firefox-addons",
         "home-manager": "home-manager",
         "m4b-tool": "m4b-tool",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "scripts": "scripts"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1732885410,
-        "narHash": "sha256-2j7D78uvwmlK8pjrMlgLQ8TaeBanDh+XelecDIhYBuY=",
+        "lastModified": 1733488732,
+        "narHash": "sha256-Evin/MkMF+U1zSFCpCcHsxJQg78ilouObSr7YGAH8v0=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "9eee63f59ec8d181539d1920a0540094769706ac",
+        "rev": "656d7f28b05f70d132851c8655771f1a29e25a76",
         "type": "gitlab"
       },
       "original": {
@@ -78,16 +78,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1726989464,
-        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "lastModified": 1733482664,
+        "narHash": "sha256-ZD+h1fwvZs+Xvg46lzTWveAqyDe18h9m7wZnTIJfFZ4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "rev": "e38d3dd1d355a003cc63e8fe6ff66ef2257509ed",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -116,27 +116,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732749044,
-        "narHash": "sha256-T38FQOg0BV5M8FN1712fovzNakSOENEYs+CSkg31C9Y=",
+        "lastModified": 1733412085,
+        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c5b4ecbed5b155b705336aa96d878e55acd8685",
+        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1732521221,
-        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "eww": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1732092125,
+        "narHash": "sha256-1bdyeeReta5ethFghMJIE5ptQ4MBLXuBdCh6mhZ8mZo=",
+        "owner": "elkowar",
+        "repo": "eww",
+        "rev": "86dc4a4636dad3999db29975d8a720831a076695",
+        "type": "github"
+      },
+      "original": {
+        "owner": "elkowar",
+        "repo": "eww",
+        "type": "github"
+      }
+    },
     "firefox-addons": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -21,6 +41,22 @@
         "owner": "rycee",
         "repo": "nur-expressions",
         "type": "gitlab"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1709944340,
+        "narHash": "sha256-xr54XK0SjczlUxRo5YwodibUSlpivS9bqHt8BNyWVQA=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "baa7aa7bd0a570b3b9edd0b8da859fee3ffaa4d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "ref": "refs/pull/65/head",
+        "repo": "flake-compat",
+        "type": "github"
       }
     },
     "flake-utils": {
@@ -95,7 +131,7 @@
     "m4b-tool": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1722229572,
@@ -114,16 +150,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680758185,
-        "narHash": "sha256-sCVWwfnk7zEX8Z+OItiH+pcSklrlsLZ4TJTtnxAYREw=",
-        "owner": "NixOS",
+        "lastModified": 1725534445,
+        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e19daa510e47a40e06257e205965f3b96ce0ac9",
+        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -146,6 +182,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1680758185,
+        "narHash": "sha256-sCVWwfnk7zEX8Z+OItiH+pcSklrlsLZ4TJTtnxAYREw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e19daa510e47a40e06257e205965f3b96ce0ac9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1733412085,
         "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
         "owner": "NixOS",
@@ -162,12 +214,34 @@
     },
     "root": {
       "inputs": {
+        "eww": "eww",
         "firefox-addons": "firefox-addons",
         "home-manager": "home-manager",
         "m4b-tool": "m4b-tool",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "scripts": "scripts"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "eww",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1725675754,
+        "narHash": "sha256-hXW3csqePOcF2e/PYnpXj72KEYyNj2HzTrVNmS/F7Ug=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8cc45e678e914a16c8e224c3237fb07cf21e5e54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "scripts": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
         };
         m4b-tool = {
             url = "github:sandreas/m4b-tool/5b0821449c529449a188bec521d51e00eefe52a2";
-            inputs.nixpkgs.follows = "nixpkgs";
         };
         scripts = {
             url = "github:nudelkurre/scripts";

--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,12 @@
             url = "github:nudelkurre/scripts";
             inputs.nixpkgs.follows = "nixpkgs";
         };
+        eww = {
+            url = "github:elkowar/eww";
+        };
     };
 
-    outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, firefox-addons, m4b-tool, scripts, ... }: 
+    outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, firefox-addons, m4b-tool, scripts, eww, ... }: 
     let
         system = "x86_64-linux";
         overlay-unstable = final: prev: {
@@ -39,6 +42,9 @@
         scripts-overlay = final: prev: {
             scripts = scripts.packages.${system};
         };
+        eww-overlay = final: prev: {
+            eww-git = eww.packages.${system};
+        };
         pkgs = import nixpkgs {
             inherit system;
             overlays = [
@@ -47,6 +53,7 @@
                 firefox-addons-overlay
                 mypkgs-overlay
                 scripts-overlay
+                eww-overlay
             ];
         };
     in {

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
     description = "A very basic flake";
 
     inputs = {
-        nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+        nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
         nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
         home-manager = {
-            url = "github:nix-community/home-manager/release-24.05";
+            url = "github:nix-community/home-manager/release-24.11";
             inputs.nixpkgs.follows = "nixpkgs";
         };
         firefox-addons = {

--- a/home-manager/apps/eww/eww.nix
+++ b/home-manager/apps/eww/eww.nix
@@ -118,7 +118,7 @@ let
     widget_windows = builtins.map
         (w:
             "(defwindow ${w.name}
-                :monitor ${toString w.id}
+                :monitor ${w.id}
                 :geometry (geometry
                                 :x \"${toString w.x}\"
                                 :y \"${toString w.y}\"
@@ -138,7 +138,7 @@ let
     windows_options = builtins.map
         (w:
             "(defwindow ${w.name}
-                :monitor ${toString w.id}
+                :monitor ${w.id}
                 :geometry (geometry
                                 :x \"0\"
                                 :y \"0\"

--- a/home-manager/cli-tools/bash.nix
+++ b/home-manager/cli-tools/bash.nix
@@ -5,16 +5,6 @@
         enableCompletion = true;
         historyControl = [ "ignoredups" ];
         bashrcExtra = ''
-m4b-merge() {
-    IFS=$'\n'
-
-    for i in $(find . -type f -name "*.m4b" | cut -d "/" -f2 | sort -uV); do ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool split $i/*.m4b --output-dir=Splitted/$i --no-conversion -v && ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool merge Splitted/$i/*.m4b --output-file=$1/$i/$i.m4b --no-conversion -v && rm -r Splitted; done
-
-    for i in $(find . -type f -name "*.m4a" | cut -d "/" -f2 | sort -uV); do ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool merge $i/*.m4a --output-file=$1/$i/$i.m4b -v; done
-
-    for i in $(find . -type f -name "*.mp3" | cut -d "/" -f2 | sort -uV); do ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool merge $i/*.mp3 --output-file=$1/$i/$i.m4b -v; done
-}
-
 PS1="\\w> "
         '';
         sessionVariables = {

--- a/home-manager/cli-tools/eza.nix
+++ b/home-manager/cli-tools/eza.nix
@@ -9,6 +9,6 @@
             "--octal-permissions"
         ];
         git = true;
-        icons = true;
+        icons = "auto";
     };
 }

--- a/home-manager/home-desktop.nix
+++ b/home-manager/home-desktop.nix
@@ -127,10 +127,11 @@
         text-color = "rgb(255,255,255)";
         icon-font = "MonaspiceRn Nerd Font Propo";
         icon-size = 20;
+        testing = true;
         bars = [
             {
                 name = "main";
-                id = 0;
+                id = "\"DP-1\"";
                 width = 2560;
                 widgets = [
                     "(workspace :monitor \"DP-1\")"
@@ -144,7 +145,7 @@
             }
             {
                 name = "secondary";
-                id = 1;
+                id = "\"HDMI-A-1\"";
                 width = 1080;
                 widgets = [
                     "(workspace :monitor \"HDMI-A-1\")"
@@ -160,7 +161,7 @@
         widgets = [
             {
                 name = "weather";
-                id = 0;
+                id = "\"DP-1\"";
                 x = 10;
                 y = 10;
                 width = 20;

--- a/home-manager/home-desktop.nix
+++ b/home-manager/home-desktop.nix
@@ -268,12 +268,28 @@
     # Home Manager is pretty good at managing dotfiles. The primary way to manage
     # plain files is through 'home.file'.
     home.file = {
+        "m4b-merge" = {
+            enable = true;
+            executable = true;
+            target = ".local/bin/m4b-merge";
+            text = ''
+                #!/usr/bin/env bash
+                
+                IFS=$'\n'
 
+                for i in $(find . -type f -name "*.m4b" | cut -d "/" -f2 | sort -uV); do ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool split $i/*.m4b --output-dir=Splitted/$i --no-conversion -v && ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool merge Splitted/$i/*.m4b --output-file=$1/$i/$i.m4b --no-conversion -v && rm -r Splitted; done
+
+                for i in $(find . -type f -name "*.m4a" | cut -d "/" -f2 | sort -uV); do ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool merge $i/*.m4a --output-file=$1/$i/$i.m4b -v; done
+
+                for i in $(find . -type f -name "*.mp3" | cut -d "/" -f2 | sort -uV); do ${pkgs.m4b-tool.m4b-tool-libfdk}/bin/m4b-tool merge $i/*.mp3 --output-file=$1/$i/$i.m4b -v; done
+            '';
+        };
     };
 
     home.sessionVariables = {
         EDITOR = "nano";
         MANGADEXDL_CONFIG_ENABLED = "1";
+        PATH = "$PATH:$HOME/.local/bin";
     };
 
     # Let Home Manager install and manage itself.

--- a/home-manager/home-desktop.nix
+++ b/home-manager/home-desktop.nix
@@ -46,9 +46,9 @@
     # The home.packages option allows you to install Nix packages into your
     # environment.
     home.packages = with pkgs; [
-        cinnamon.nemo
+        nemo
         mypkgs.freetube
-        gnome.seahorse
+        seahorse
         hyprpaper
         imv
         kbfs

--- a/home-manager/home-laptop.nix
+++ b/home-manager/home-laptop.nix
@@ -108,7 +108,7 @@
         bars = [
             {
                 name = "main";
-                id = 0;
+                id = "\"LVDS-1\"";
                 width = 1366;
                 widgets = [
                     "(workspace :monitor \"LVDS-1\")"
@@ -123,7 +123,7 @@
             }
             {
                 name = "secondary";
-                id = 1;
+                id = "\"HDMI-A-1\"";
                 width = 1280;
                 widgets = [
                     "(workspace :monitor \"HDMI-A-1\")"
@@ -139,7 +139,7 @@
         widgets = [
             {
                 name = "weather";
-                id = 0;
+                id = "\"LVDS-1\"";
                 x = 10;
                 y = 10;
                 width = 20;

--- a/home-manager/home-laptop.nix
+++ b/home-manager/home-laptop.nix
@@ -232,7 +232,7 @@
     # The home.packages option allows you to install Nix packages into your
     # environment.
     home.packages = with pkgs; [
-        cinnamon.nemo
+        nemo
         mypkgs.freetube
         hyprpaper
         imv

--- a/home-manager/window-managers/hyprland.nix
+++ b/home-manager/window-managers/hyprland.nix
@@ -197,10 +197,6 @@
                 fullscreen_opacity = "1.0";
                 dim_inactive = false;
                 dim_strength = "0.5";
-                "drop_shadow" = true;
-                "shadow_range" = "4";
-                "shadow_render_power" = "1";
-                "col.shadow" = "rgba(101010ee)";
 
                 blur = {
                     enabled = true;
@@ -221,13 +217,11 @@
                 preserve_split = true;
                 smart_split = false;
                 smart_resizing = true;
-                no_gaps_when_only = "0";
             };
 
             master = {
                 allow_small_split = false;
                 new_status = "slave";
-                no_gaps_when_only = "0";
                 orientation = "left";
                 mfact = "0.5";
             };

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -105,15 +105,14 @@
         # Disable Intel SGX
         cpu.intel.sgx.provision.enable = false;
         # Hardware accelerating
-        opengl = {
+        graphics = {
             enable = true;
+            enable32Bit = true;
             extraPackages = with pkgs; [
                 intel-vaapi-driver
                 intel-media-driver
                 rocmPackages.clr.icd
             ];
-            driSupport = true;
-            driSupport32Bit = true;
         };
         # Drivers for Xbox Series X|S controller
         xpadneo.enable = true;

--- a/nixos/laptop.nix
+++ b/nixos/laptop.nix
@@ -87,7 +87,7 @@
             };
         };
         # Hardware accelerating
-        opengl = {
+        graphics = {
             enable = true;
             extraPackages = with pkgs; [
                 vaapiIntel

--- a/options.nix
+++ b/options.nix
@@ -6,7 +6,7 @@ with lib;
             enable = mkEnableOption "eww";
             package = mkOption {
                 type = types.package;
-                default = pkgs.eww;
+                default = pkgs.eww-git.eww;
                 defaultText = literalExpression "pkgs.eww";
                 example = literalExpression "pkgs.eww";
                 description = ''
@@ -56,10 +56,10 @@ with lib;
                             description = "Set the name of the bar";
                         };
                         id = mkOption {
-                            type = types.int;
-                            example = 1;
-                            default = 0;
-                            description = "Monitor id to use";
+                            type = types.str;
+                            example = "1";
+                            default = "0";
+                            description = "Monitor id or name to use";
                         };
                         widgets = mkOption {
                             type = types.listOf types.str;
@@ -84,10 +84,10 @@ with lib;
                             description = "Set the name of the widget";
                         };
                         id = mkOption {
-                            type = types.int;
-                            example = 1;
-                            default = 0;
-                            description = "Monitor id to use";
+                            type = types.str;
+                            example = "1";
+                            default = "0";
+                            description = "Monitor id or name to use";
                         };
                         modules = mkOption {
                             type = types.listOf types.str;


### PR DESCRIPTION
Updated flake to use Nixos 24.11
Changed to use "hardware.graphics" instead for removed settings "hardware.opengl"
Changed "programs.eza.icon" from using true to auto"
Change to not follow local nixpkgs for m4b-tool since ffmpeg is needed but removed from nixpkgs
Moved function for "m4b-merge" from bashrc to separate script
Updated eww to use own flake to get newer version with support for monitor names instead of only id for bars and widgets